### PR TITLE
Add "dependencies" field to two mods

### DIFF
--- a/Kenan-Structured-Modpack/pixels_fuckery/modinfo.json
+++ b/Kenan-Structured-Modpack/pixels_fuckery/modinfo.json
@@ -5,6 +5,7 @@
     "name": "Pixel's Various Fuckery",
     "description": "Adds additional unique post-threshold mutations, various recipes for weapons.  Slightly risqué but safe for work, no worse than vibrators and gimp suits!@#",
     "category": "items",
-    "authors": [ "pixel and Eirenex" ]
+    "authors": [ "pixel and Eirenex" ],
+    "dependencies": [ "dda" ]
   }
 ]

--- a/Kenan-Structured-Modpack/whaleys-hair-and-tattoo/modinfo.json
+++ b/Kenan-Structured-Modpack/whaleys-hair-and-tattoo/modinfo.json
@@ -7,6 +7,7 @@
     "category": "graphical",
     "authors": "Whaley",
     "maintainers": "Neon",
+    "dependencies": [ "dda" ],
     "path": ""
 }
 ]


### PR DESCRIPTION
I'm trying to create some sort of CI with CNK and DDA. 

Lacking this field creates trouble in running cataclysm-tiles with command line option "--check-mods". As CNK is DDA-only and it isn't likely that this will introduce conflicts with Kenan's repo, I'm submitting this.

If you would like to merge this, please squash and merge.